### PR TITLE
chore: update footer year to 2026

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -46,7 +46,7 @@
     </main>
 
     <footer class="bg-gray-400 text-white text-center py-4 mt-10">
-        <p>&copy; Human Sensing Group 2025</p>
+        <p>&copy; Human Sensing Group 2026</p>
     </footer>
 
     <script>

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
     </main>
 
     <footer class="bg-gray-400 text-white text-center py-4 mt-10">
-        <p>&copy; Human Sensing Group 2025</p>
+        <p>&copy; Human Sensing Group 2026</p>
     </footer>
     <script>
         // JavaScriptでheader.htmlを読み込む

--- a/kentaro.html
+++ b/kentaro.html
@@ -119,7 +119,7 @@
     </main>
 
     <footer class="bg-gray-800 text-white text-center py-4 mt-10">
-        <p>&copy; Human Sensing Group 2025</p>
+        <p>&copy; Human Sensing Group 2026</p>
     </footer>
     <script>
         // JavaScriptでheader.htmlを読み込む

--- a/member.html
+++ b/member.html
@@ -88,7 +88,7 @@
     </main>
 
     <footer class="bg-gray-400 text-white text-center py-4 mt-10">
-        <p>&copy; Human Sensing Group 2025</p>
+        <p>&copy; Human Sensing Group 2026</p>
     </footer>
 
     <script>

--- a/publication.html
+++ b/publication.html
@@ -276,7 +276,7 @@
                 </ol>
             </details>                    
      <footer class="bg-gray-400 text-white text-center py-4 mt-10">
-        <p>&copy; Human Sensing Group 2025</p>
+        <p>&copy; Human Sensing Group 2026</p>
     </footer>
 
     <script>

--- a/research.html
+++ b/research.html
@@ -297,7 +297,7 @@
     </main>
 
     <footer class="bg-gray-400 text-white text-center py-4 mt-10">
-        <p>&copy; Human Sensing Group 2025</p>
+        <p>&copy; Human Sensing Group 2026</p>
     </footer>
 
     <script>


### PR DESCRIPTION
## Summary
- Update footer copyright year from 2025 to 2026 across all HTML pages

## Testing
- Not run (content-only HTML change)